### PR TITLE
DTO 생성 ~ JPA Repository 연동 기능 개발 PR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -268,3 +268,4 @@ gradle-app.setting
 # End of https://www.toptal.com/developers/gitignore/api/intellij,eclipse,maven,gradle,java,git
 /HELP.md
 /delivery.iml
+/src/main/resources/application-aws.properties

--- a/build.gradle
+++ b/build.gradle
@@ -22,10 +22,10 @@ repositories {
 }
 
 dependencies {
-    // implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     compileOnly 'org.projectlombok:lombok'
-    // runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client:2.7.4'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/src/main/java/com/sjc/delivery/food/controller/FoodController.java
+++ b/src/main/java/com/sjc/delivery/food/controller/FoodController.java
@@ -1,6 +1,7 @@
 package com.sjc.delivery.food.controller;
 
 import com.sjc.delivery.food.domain.Food;
+import com.sjc.delivery.food.dto.FoodDto;
 import com.sjc.delivery.food.service.FoodService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -22,9 +23,13 @@ public class FoodController {
     }
 
     @PostMapping("/foods")
-    public String registFood(@RequestBody Food food){
-        foodService.save(food);
-        return "ok";
+    public FoodDto registFood(@RequestBody FoodDto foodDto){
+        // DTO -> Entity 변환
+        Food request = toEntity(foodDto);
+        Food response = foodService.save(request);
+
+        // Entity -> DTO 변환
+        return toResponse(response);
     }
 
     @GetMapping("/foods/{foodId}")
@@ -33,14 +38,33 @@ public class FoodController {
     }
 
     @PutMapping("/foods")
-    public String updateFood(@RequestBody Food food){
-        foodService.saveAndFlush(food);
-        return "ok";
+    public FoodDto updateFood(@RequestBody FoodDto foodDto){
+        Food request = toEntity(foodDto);
+        Food response = foodService.saveAndFlush(request);
+        return toResponse(response);
     }
 
     @DeleteMapping("/foods/{foodId}")
-    public String updateFood(@PathVariable Long foodId){
-        foodService.deleteById(foodId);
-        return "ok";
+    public int updateFood(@PathVariable Long foodId){
+        return foodService.deleteById(foodId);
+    }
+
+    public static Food toEntity(FoodDto req) {
+        return Food.builder()
+            .foodName(req.getFoodName())
+            .foodType(req.getFoodType())
+            .price(req.getPrice())
+            .description(req.getDescription())
+            .build();
+    }
+
+    public static FoodDto toResponse (Food entity) {
+        return FoodDto.builder()
+            .id(entity.getId())
+            .foodName(entity.getFoodName())
+            .foodType(entity.getFoodType())
+            .price(entity.getPrice())
+            .description(entity.getDescription())
+            .build();
     }
 }

--- a/src/main/java/com/sjc/delivery/food/domain/Food.java
+++ b/src/main/java/com/sjc/delivery/food/domain/Food.java
@@ -1,12 +1,23 @@
 package com.sjc.delivery.food.domain;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @AllArgsConstructor
+@NoArgsConstructor
+@Builder
 @Getter
+@Entity
 public class Food {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private Long storeId;
     private String foodName;

--- a/src/main/java/com/sjc/delivery/food/domain/Food.java
+++ b/src/main/java/com/sjc/delivery/food/domain/Food.java
@@ -4,15 +4,14 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@AllArgsConstructor
-@NoArgsConstructor
-@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
 public class Food {
@@ -25,7 +24,17 @@ public class Food {
     private String foodType;
     private String description;
 
+    @Builder
+    public Food(String foodName, int price, String foodType, String description) {
+        this.foodName = foodName;
+        this.price = price;
+        this.foodType = foodType;
+        this.description = description;
+    }
+
     public void setId(Long id) {
         this.id = id;
     }
+
+
 }

--- a/src/main/java/com/sjc/delivery/food/dto/FoodDto.java
+++ b/src/main/java/com/sjc/delivery/food/dto/FoodDto.java
@@ -1,0 +1,17 @@
+package com.sjc.delivery.food.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class FoodDto {
+    private Long id;
+    private Long storeId;
+    private String foodName;
+    private int price;
+    private String foodType;
+    private String description;
+}

--- a/src/main/java/com/sjc/delivery/food/repository/JpaFoodRepository.java
+++ b/src/main/java/com/sjc/delivery/food/repository/JpaFoodRepository.java
@@ -5,12 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface FoodRepository {
-    Food save(Food food);
+public interface JpaFoodRepository extends JpaRepository<Food, Long>,FoodRepository {
 
-    Food findById(long id);
-
-    Food saveAndFlush(Food food);
-
-    int deleteById(long id);
 }

--- a/src/main/java/com/sjc/delivery/food/repository/MemoryFoodRepository.java
+++ b/src/main/java/com/sjc/delivery/food/repository/MemoryFoodRepository.java
@@ -4,7 +4,7 @@ import com.sjc.delivery.food.domain.Food;
 import java.util.HashMap;
 import org.springframework.stereotype.Repository;
 
-@Repository
+//@Repository
 public class MemoryFoodRepository implements FoodRepository {
 
     private HashMap<Long, Food> db = new HashMap<>();
@@ -29,7 +29,11 @@ public class MemoryFoodRepository implements FoodRepository {
     }
 
     @Override
-    public void deleteById(long id) {
+    public int deleteById(long id) {
+        if(!db.containsKey(id)){
+            return 0;
+        }
         db.remove(id);
+        return 1;
     }
 }

--- a/src/main/java/com/sjc/delivery/food/service/FoodService.java
+++ b/src/main/java/com/sjc/delivery/food/service/FoodService.java
@@ -10,6 +10,6 @@ public interface FoodService {
 
     Food saveAndFlush(Food food);
 
-    void deleteById(long id);
+    int deleteById(long id);
 
 }

--- a/src/main/java/com/sjc/delivery/food/service/FoodServiceImpl.java
+++ b/src/main/java/com/sjc/delivery/food/service/FoodServiceImpl.java
@@ -1,6 +1,7 @@
 package com.sjc.delivery.food.service;
 
 import com.sjc.delivery.food.domain.Food;
+import com.sjc.delivery.food.dto.FoodDto;
 import com.sjc.delivery.food.repository.FoodRepository;
 import org.springframework.stereotype.Service;
 
@@ -29,7 +30,7 @@ public class FoodServiceImpl implements FoodService{
     }
 
     @Override
-    public void deleteById(long id) {
-        foodRepository.deleteById(id);
+    public int deleteById(long id) {
+        return foodRepository.deleteById(id);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,10 @@
+spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
+spring.datasource.url=jdbc:mariadb://localhost:3306/delivery
+spring.datasource.username=dev
+spring.datasource.password=1234
 
+spring.jpa.hibernate.ddl-auto=create
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.show-sql=true
+logging.level.org.hibernate.type.descriptor.sql=DEBUG
+logging.level.org.hibernate.SQL=DEBUG

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,9 +1,7 @@
-spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
-spring.datasource.url=jdbc:mariadb://localhost:3306/delivery
-spring.datasource.username=dev
-spring.datasource.password=1234
+# DB
+spring.profiles.include=aws
 
-spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.show-sql=true
 logging.level.org.hibernate.type.descriptor.sql=DEBUG


### PR DESCRIPTION
기존 Memory DB (hashMap 사용) 하는 구조에서 JPA(MariaDB)로 설정 변경하였습니다. 
**[변경 후]**
- Food 클래스 @Entity 어노테이션을 활용한 JPA용 엔티티로 변경하였습니다. 
- JpaFoodRepository 인터페이스를 구현하여 기존 FoodRepository 와 JPA 활용을 위해 JpaRepository를 상속받는 형태로 생성하였습니다. 

- 기존 Entity 클래스로 계층이동 하던 구조를 DTO를 사용하여 변경하였습니다. 

**앞으로 할 일**
- 이미 작성한 API 기준하에 DB ERD 및 도메인 구조 파악해서 프로젝트 적용
- 프로젝트 시작 전 지켜야할 컨벤션 정해보기 ( GIt message, Code Convention 등...)
- 프로젝트 공통 세팅 정하기 ( 패키지 구성, DI , DTO 변환, 예외처리, Validation, Code ...)